### PR TITLE
Use file instead of module.resource

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,16 +15,16 @@ WebpackKarmaDieHardPlugin.prototype.apply = function(compiler) {
     // Need to report warnings and errors manually, since these will not bubble
     // up to the user.
     stats.compilation.warnings.forEach(function (warning) {
-      if (warning.module) {
-        console.warn(chalk.yellow("WARNING: ./"
-            + path.relative("", warning.module.resource)));
+      if (warning.file) {
+        console.warn(chalk.yellow("WARNING in ./"
+          + path.relative("", warning.file)));
       }
       console.warn(chalk.yellow(warning.message || warning));
     });
     stats.compilation.errors.forEach(function (error) {
-      if (error.module) {
-        console.error(chalk.red("ERROR: ./"
-            + path.relative("", error.module.resource)));
+      if (error.file) {
+        console.error(chalk.red("ERROR in ./"
+          + path.relative("", error.file)));
       }
       console.error(chalk.red(error.message || error));
     });


### PR DESCRIPTION
With "webpack": "~1.14.0" and "karma-webpack": "1.7.0" file path was not rendered with module.resource, here is how error object looked:
```
error { message: '\u001b[37m(\u001b[39m\u001b[36m7\u001b[39m,\u001b[36m16\u001b[39m): \u001b[31merror TS2307: Cannot find module \'../../ga\'.\u001b[39m',
  rawMessage: 'error TS2307: Cannot find module \'../../ga\'.',
  location: { line: 7, character: 16 },
  loaderSource: 'ts-loader',
  file: '/Users/tb/projects/builder/app/admin.component.ts' }
(7,16): error TS2307: Cannot find module '../../ga'.
```
Using file fixed display of error location.

